### PR TITLE
feature/11: Deactivate entity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5334,6 +5334,11 @@
         "sliced": "1.0.1"
       }
     },
+    "mongoose-delete": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/mongoose-delete/-/mongoose-delete-0.4.0.tgz",
+      "integrity": "sha1-bu7tVti0eM8JrgK1iU0ROABWvko="
+    },
     "mongoose-legacy-pluralize": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "iso-639-1": "^2.0.3",
     "jsonwebtoken": "^8.2.1",
     "mongoose": "^5.1.2",
+    "mongoose-delete": "^0.4.0",
     "node-schedule": "^1.3.0",
     "nodemailer": "^4.6.4",
     "nodemon": "^1.17.4",

--- a/src/controllers/entityController.js
+++ b/src/controllers/entityController.js
@@ -179,7 +179,7 @@ export function dislikeEntity(req, res) {
                 if (err) return res.status(constants.STATUS_SERVER_ERROR).send(err);
                 let index = beneficiary.likedEntities.indexOf(entity._id);
                 if (index !== -1) {
-                    beneficiary.likedEntities.splice(index,1);
+                    beneficiary.likedEntities.splice(index, 1);
                     beneficiary.save();
                     entity.numberLikes -= 1;
                     entity.save();
@@ -188,6 +188,17 @@ export function dislikeEntity(req, res) {
                     return res.status(constants.STATUS_CONFLICT).send({message: "You do not like this entity yet"});
                 }
             });
+        });
+    } else {
+        res.status(constants.STATUS_FORBIDDEN).send({message: "You are not allowed to do this action"});
+    }
+}
+
+export function deactivateEntity(req, res) {
+    if (req.userType === 'Entity') {
+        entityModel.delete({email: req.userId}, function (err, result) {
+            if (err) return res.status(constants.STATUS_SERVER_ERROR).send(err);
+            res.status(constants.STATUS_OK).send({message: "Entity deactivation with result: " + result});
         });
     } else {
         res.status(constants.STATUS_FORBIDDEN).send({message: "You are not allowed to do this action"});

--- a/src/models/beneficiaryModel.js
+++ b/src/models/beneficiaryModel.js
@@ -1,6 +1,7 @@
 import mongoose from "mongoose";
 
 import {userModel} from "./userModel";
+import mongoose_delete from "mongoose-delete";
 
 const briefGoodSchema = new mongoose.Schema({
     id: {
@@ -12,7 +13,7 @@ const briefGoodSchema = new mongoose.Schema({
     }
 },{_id: false});
 
-export const beneficiaryModel = userModel.discriminator('Beneficiary', new mongoose.Schema({
+const beneficiarySchema = new mongoose.Schema({
     firstName: {
         type: String,
         required: true
@@ -30,4 +31,8 @@ export const beneficiaryModel = userModel.discriminator('Beneficiary', new mongo
         ref: 'Entity'
     }],
     usedGoods: [briefGoodSchema]
-}));
+});
+
+beneficiarySchema.plugin(mongoose_delete);
+
+export const beneficiaryModel = userModel.discriminator('Beneficiary', beneficiarySchema);

--- a/src/models/beneficiaryModel.js
+++ b/src/models/beneficiaryModel.js
@@ -1,7 +1,7 @@
 import mongoose from "mongoose";
+import mongoose_delete from "mongoose-delete";
 
 import {userModel} from "./userModel";
-import mongoose_delete from "mongoose-delete";
 
 const briefGoodSchema = new mongoose.Schema({
     id: {

--- a/src/models/beneficiaryModel.js
+++ b/src/models/beneficiaryModel.js
@@ -33,6 +33,6 @@ const beneficiarySchema = new mongoose.Schema({
     usedGoods: [briefGoodSchema]
 });
 
-beneficiarySchema.plugin(mongoose_delete);
+beneficiarySchema.plugin(mongoose_delete, { overrideMethods: true });
 
 export const beneficiaryModel = userModel.discriminator('Beneficiary', beneficiarySchema);

--- a/src/models/entityModel.js
+++ b/src/models/entityModel.js
@@ -1,9 +1,10 @@
 import mongoose from "mongoose";
 import passwordGenerator from "password-generator";
+import mongoose_delete from "mongoose-delete";
 
 import {userModel} from "./userModel";
 
-export const entityModel = userModel.discriminator('Entity', new mongoose.Schema({
+const entitySchema = new mongoose.Schema({
     salesmanFirstName: {
         type: String,
         required: true
@@ -44,4 +45,8 @@ export const entityModel = userModel.discriminator('Entity', new mongoose.Schema
         type: Number,
         default: 0
     }
-}).index({coordinates: '2dsphere'}));
+}).index({coordinates: '2dsphere'});
+
+entitySchema.plugin(mongoose_delete);
+
+export const entityModel = userModel.discriminator('Entity', entitySchema);

--- a/src/models/entityModel.js
+++ b/src/models/entityModel.js
@@ -43,9 +43,5 @@ export const entityModel = userModel.discriminator('Entity', new mongoose.Schema
     numberLikes: {
         type: Number,
         default: 0
-    },
-    enabled: {
-        type: Boolean,
-        default: false
     }
 }).index({coordinates: '2dsphere'}));

--- a/src/models/entityModel.js
+++ b/src/models/entityModel.js
@@ -47,6 +47,6 @@ const entitySchema = new mongoose.Schema({
     }
 }).index({coordinates: '2dsphere'});
 
-entitySchema.plugin(mongoose_delete);
+entitySchema.plugin(mongoose_delete, { overrideMethods: true });
 
 export const entityModel = userModel.discriminator('Entity', entitySchema);

--- a/src/models/userModel.js
+++ b/src/models/userModel.js
@@ -1,5 +1,6 @@
 import mongoose from "mongoose";
 import bcrypt from "bcryptjs";
+import mongoose_delete from "mongoose-delete";
 
 import {LANGUAGES} from '../constants';
 
@@ -32,6 +33,8 @@ const userSchema = new mongoose.Schema({
         default: 'en'
     }
 }, baseOptions);
+
+userSchema.plugin(mongoose_delete);
 
 userSchema.pre('save', function (next) {
     if (!this.isModified('password')) return next();

--- a/src/models/userModel.js
+++ b/src/models/userModel.js
@@ -34,7 +34,7 @@ const userSchema = new mongoose.Schema({
     }
 }, baseOptions);
 
-userSchema.plugin(mongoose_delete);
+userSchema.plugin(mongoose_delete, { overrideMethods: true });
 
 userSchema.pre('save', function (next) {
     if (!this.isModified('password')) return next();

--- a/src/routes/apiRouter.js
+++ b/src/routes/apiRouter.js
@@ -105,6 +105,15 @@ apiRouter.get('/', function (req, res) {
 });
 
 /**
+ * @api {delete} /me Deactivate entity
+ * @apiVersion 1.0.0
+ * @apiGroup Authentication
+ */
+apiRouter.delete('/', function (req, res) {
+    entityController.deactivateEntity(req, res);
+});
+
+/**
  * @api {put} /me/password Token validation
  * @apiVersion 1.0.0
  * @apiGroup Authentication


### PR DESCRIPTION
Falta fer els testos i provar que funcioni correctament.

Introduïm un plugin que substitueix la logica de Mongoose per un soft-delete (aplicat per-schema). Permet desactivar/reactivar documents i guarda historic de qui/quan ha modificat l'estat. LA cerca per defecte no inclou els desactivats pero introdueix nous metodes per fer aixo mateix.